### PR TITLE
Modify variables to be more puppet familiar.

### DIFF
--- a/manifests/server/module.pp
+++ b/manifests/server/module.pp
@@ -5,13 +5,13 @@
 # Parameters:
 #   $path            - path to data
 #   $comment         - rsync comment
-#   $read_only       - yes||no, defaults to yes
-#   $write_only      - yes||no, defaults to no
-#   $list            - yes||no, defaults to yes
+#   $read_only       - true||false, defaults to true
+#   $write_only      - true||false, defaults to false
+#   $list            - true||false, defaults to true
 #   $uid             - uid of rsync server, defaults to 0
 #   $gid             - gid of rsync server, defaults to 0
-#   $incoming_chmod  - incoming file mode, defaults to 0644
-#   $outgoing_chmod  - outgoing file mode, defaults to 0644
+#   $incoming_chmod  - incoming file mode, defaults to 0644, can be set to false
+#   $outgoing_chmod  - outgoing file mode, defaults to 0644, can be set to false
 #   $max_connections - maximum number of simultaneous connections allowed, defaults to 0
 #   $lock_file       - file used to support the max connections parameter, defaults to /var/run/rsyncd.lock
 #    only needed if max_connections > 0
@@ -32,15 +32,21 @@
 define rsync::server::module (
   $path,
   $comment         = undef,
-  $read_only       = 'yes',
-  $write_only      = 'no',
-  $list            = 'yes',
+  $read_only       = true,
+  $write_only      = false,
+  $list            = true,
   $uid             = '0',
   $gid             = '0',
   $incoming_chmod  = '0644',
   $outgoing_chmod  = '0644',
   $max_connections = '0',
-  $lock_file       = '/var/run/rsyncd.lock')  {
+  $lock_file       = '/var/run/rsyncd.lock'
+) {
+
+  # Converting booleans to yes/no.
+  $read_only_real = $read_only ? { true  => 'yes', false => 'no', }
+  $write_only_real = $write_only ? { true  => 'yes', false => 'no', }
+  $list_real = $list ? { true  => 'yes', false => 'no', }
 
   file { "${rsync::server::rsync_fragments}/frag-${name}":
     content => template('rsync/module.erb'),

--- a/templates/module.erb
+++ b/templates/module.erb
@@ -3,13 +3,13 @@
 
 [ <%= name %> ]
 path            = <%= path %>
-read only       = <%= read_only %>
-write only      = <%= write_only %>
-list            = <%= list %>
+read only       = <%= read_only_real %>
+write only      = <%= write_only_real %>
+list            = <%= list_real %>
 uid             = <%= uid %>
 gid             = <%= gid %>
-incoming chmod  = <%= incoming_chmod %>
-outgoing chmod  = <%= outgoing_chmod %>
+<% if incoming_chmod != false -%>incoming chmod  = <%= "#{incoming_chmod}\n" %><% end -%>
+<% if outgoing_chmod != false -%>outgoind chmod  = <%= "#{outgoing_chmod}\n" %><% end -%>
 max connections = <%= max_connections %>
 <% if Integer(max_connections) > 0 %>lock file =     <%= lock_file %><% end %>
 <% if comment != :undef %>comment               = <%= comment %><% end %>


### PR DESCRIPTION
Change the use of yes/no for read/write/list to be true and false.
  Accomplish through modifications of parameters in the
  rsync::server::module class and supporting template data.  Similar to
  happen to incoming_{uid,gid}, allowing the use of false.

  Previously the interface represented was a departure from common types
  available in Puppet.
