### PR TITLE
A path needs to be defined from Exec resources.

### DIFF
--- a/manifests/get.pp
+++ b/manifests/get.pp
@@ -60,6 +60,7 @@ define rsync::get (
 
   exec { "rsync ${name}":
     command => "rsync -qa ${MyPurge} ${MyExclude} ${MyUser}${source} ${MyPath}",
+    path    => [ '/bin', '/usr/bin' ],
     timeout => $timeout,
   }
 }


### PR DESCRIPTION
Add a path attribute to the Exec resource used in rsync::get defined
  type.

  Previously a user would get an error if they haven't defined a
  resource default for Exec.
