### PR TITLE
Make rsync::get idempotent

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,2 @@
+require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'

--- a/manifests/get.pp
+++ b/manifests/get.pp
@@ -58,9 +58,18 @@ define rsync::get (
     $MyPath = $name
   }
 
+  $rsync_options = "-a ${MyPurge} ${MyExclude} ${MyUser}${source} ${MyPath}"
+
   exec { "rsync ${name}":
-    command => "rsync -qa ${MyPurge} ${MyExclude} ${MyUser}${source} ${MyPath}",
+    command => "rsync -q ${rsync_options}",
     path    => [ '/bin', '/usr/bin' ],
+    # perform a dry-run to determine if anything needs to be updated
+    # this ensures that we only actually create a Puppet event if something needs to
+    # be updated
+    # TODO - it may make senes to do an actual run here (instead of a dry run)
+    #        and relace the command with an echo statement or something to ensure
+    #        that we only actually run rsync once
+    onlyif  => "test `rsync --dry-run --itemize-changes ${rsync_options} | wc -l` -gt 0",
     timeout => $timeout,
   }
 }

--- a/spec/defines/get_spec.rb
+++ b/spec/defines/get_spec.rb
@@ -17,7 +17,8 @@ describe 'rsync::get', :type => :define do
 
     it {
       should contain_exec("rsync foobar").with({
-        'command' => 'rsync -qa   example.com foobar',
+        'command' => 'rsync -q -a   example.com foobar',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a   example.com foobar | wc -l` -gt 0",
         'timeout' => '900'
       })
     }
@@ -40,7 +41,8 @@ describe 'rsync::get', :type => :define do
 
     it {
       should contain_exec("rsync foobar").with({
-        'command' => 'rsync -qa   -e \'ssh -i /home/mr_baz/.ssh/id_rsa -l mr_baz\' mr_baz@example.com foobar'
+        'command' => 'rsync -q -a   -e \'ssh -i /home/mr_baz/.ssh/id_rsa -l mr_baz\' mr_baz@example.com foobar',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a   -e \'ssh -i /home/mr_baz/.ssh/id_rsa -l mr_baz\' mr_baz@example.com foobar | wc -l` -gt 0",
       })
     }
   end
@@ -52,7 +54,8 @@ describe 'rsync::get', :type => :define do
 
     it {
       should contain_exec("rsync foobar").with({
-        'command' => 'rsync -qa   example.com foobar'
+        'command' => 'rsync -q -a   example.com foobar',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a   example.com foobar | wc -l` -gt 0",
       })
     }
   end
@@ -67,7 +70,8 @@ describe 'rsync::get', :type => :define do
 
     it {
       should contain_exec("rsync foobar").with({
-        'command' => 'rsync -qa   -e \'ssh -i /path/to/keyfile -l mr_baz\' mr_baz@example.com foobar'
+        'command' => 'rsync -q -a   -e \'ssh -i /path/to/keyfile -l mr_baz\' mr_baz@example.com foobar',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a   -e \'ssh -i /path/to/keyfile -l mr_baz\' mr_baz@example.com foobar | wc -l` -gt 0",
        })
     }
   end
@@ -79,7 +83,8 @@ describe 'rsync::get', :type => :define do
 
     it {
       should contain_exec("rsync foobar").with({
-        'command' => 'rsync -qa  --exclude=/path/to/exclude/ example.com foobar'
+        'command' => 'rsync -q -a  --exclude=/path/to/exclude/ example.com foobar',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a  --exclude=/path/to/exclude/ example.com foobar | wc -l` -gt 0",
        })
     }
   end
@@ -91,7 +96,8 @@ describe 'rsync::get', :type => :define do
 
     it {
       should contain_exec("rsync foobar").with({
-        'command' => 'rsync -qa --delete  example.com foobar'
+        'command' => 'rsync -q -a --delete  example.com foobar',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a --delete  example.com foobar | wc -l` -gt 0"
        })
     }
   end
@@ -103,7 +109,8 @@ describe 'rsync::get', :type => :define do
 
     it {
       should contain_exec("rsync foobar").with({
-        'command' => 'rsync -qa   example.com barfoo'
+        'command' => 'rsync -q -a   example.com barfoo',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a   example.com barfoo | wc -l` -gt 0"
        })
     }
   end


### PR DESCRIPTION
This commit makes the rsync::get define idenpotent. It does this by adding
a dry-run rsync call as on onlyif params that ensures that rsync will
only create an event if the file currently needs to be updated.

This change has been added to ensure that the rsync::get define does not
constantly spew events when its used.
