### PR TITLE
for get type, allow arbitrary rsync options instead of -a which may cont...

### DIFF
--- a/lib/puppet/parser/functions/valid_options.rb
+++ b/lib/puppet/parser/functions/valid_options.rb
@@ -1,0 +1,10 @@
+module Puppet::Parser::Functions
+  VERBOSE_OR_QUIET_REGEX = /\-\w*[vq]|\-\-verbose|\-\-quiet/
+
+  # returns true if the options passed doesn't contain verbose or quiet options, which mess with the rsync puppet module's
+  # ability to detect whether or not to run rsync
+  newfunction(:valid_options, :type => :rvalue) do |args|
+    options = args[0]
+    (options =~ VERBOSE_OR_QUIET_REGEX).nil?
+  end
+end

--- a/manifests/get.pp
+++ b/manifests/get.pp
@@ -33,7 +33,17 @@ define rsync::get (
   $keyfile = undef,
   $timeout = '900',
   $execuser = 'root',
+  $options = undef # overrides all other options if set
 ) {
+
+  if $options {
+    if !valid_options($options) {
+    fail("for resource ${title}, options are ${options}.  rsync options should not include -v or -q, which interfere with the ability to check for changes")
+  }
+    $rsync_flags = $options
+  } else {
+    $rsync_flags = "-a"
+  }
 
   if $keyfile {
     $Mykeyfile = $keyfile
@@ -59,7 +69,7 @@ define rsync::get (
     $MyPath = $name
   }
 
-  $rsync_options = "-a ${MyPurge} ${MyExclude} ${MyUser}${source} ${MyPath}"
+  $rsync_options = "${rsync_flags} ${MyPurge} ${MyExclude} ${MyUser}${source} ${MyPath}"
 
   exec { "rsync ${name}":
     command => "rsync -q ${rsync_options}",


### PR DESCRIPTION
...ain options we don't want.

restrict -v and -q options as they interfere with the 'onlyif' parameter working correctly
