### PR TITLE
(maint) Remove use of str2bool

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -20,7 +20,7 @@ class rsync::server(
 
   $rsync_fragments = '/etc/rsync.d'
 
-  if str2bool($use_xinetd) {
+  if $use_xinetd {
     include xinetd
     xinetd::service { 'rsync':
       bind        => $address,


### PR DESCRIPTION
str2bool gets cranky if it's passed an actual boolean value. This seems like
more hassle than it's worth, so I'm removing my singular usage of it.
