### PR TITLE
/usr/local/bin included in search path for rsync

### DIFF
--- a/manifests/get.pp
+++ b/manifests/get.pp
@@ -63,7 +63,7 @@ define rsync::get (
 
   exec { "rsync ${name}":
     command => "rsync -q ${rsync_options}",
-    path    => [ '/bin', '/usr/bin' ],
+    path    => [ '/bin', '/usr/bin', '/usr/local/bin' ],
     user => $execuser,
     # perform a dry-run to determine if anything needs to be updated
     # this ensures that we only actually create a Puppet event if something needs to

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -76,6 +76,6 @@ class rsync::server(
     refreshonly => true,
     command     => "ls ${rsync_fragments}/frag-* 1>/dev/null 2>/dev/null && if [ $? -eq 0 ]; then cat ${rsync_fragments}/header ${rsync_fragments}/frag-* > ${conf_file}; else cat ${rsync_fragments}/header > ${conf_file}; fi; $(exit 0)",
     subscribe   => File["${rsync_fragments}/header"],
-    path        => '/bin:/usr/bin',
+    path        => '/bin:/usr/bin:/usr/local/bin',
   }
 }


### PR DESCRIPTION
Hi,
Some systems do not have rsync in their base distribution and puppet unfortunately silently fails should rsync not be found in the path.

I have added '/usr/local/bin' as this is where the FreeBSD port is installed to.

Thanks & cheerio, Harry.
