### PR TITLE
fixed auto chmod of incoming and outgoing files

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -104,3 +104,13 @@ sets up a rsync server
       path    => $base,
       require => File[$base],
     }
+
+To disable default values for ``incoming_chmod`` and ``outgoing_chmod``, and
+do not add empty values to the resulting config, set both values to ``false``
+
+    rsync::server::module { 'repo':
+      path           => $base,
+      incoming_chmod => false,
+      outgoing_chmod => false,
+      require        => File[$base],
+    }

--- a/spec/defines/server_module_spec.rb
+++ b/spec/defines/server_module_spec.rb
@@ -47,6 +47,16 @@ describe 'rsync::server::module', :type => :define do
     it { is_expected.to contain_file(fragment_file).with_content(/^lock file\s*=\s*\/var\/run\/rsyncd\.lock$/) }
   end
 
+  describe "when setting incoming chmod to false" do
+    let :params do
+      mandatory_params.merge({:incoming_chmod => false,
+                              :outgoing_chmod => false,
+      })
+    end
+    it { is_expected.not_to contain_file(fragment_file).with_content(/^incoming chmod.*$/) }
+    it { is_expected.not_to contain_file(fragment_file).with_content(/^outgoing chmod.*$/) }
+  end
+
   {
     :comment        => 'super module !',
     :read_only      => 'no',

--- a/templates/module.erb
+++ b/templates/module.erb
@@ -8,8 +8,12 @@ write only      = <%= @write_only %>
 list            = <%= @list %>
 uid             = <%= @uid %>
 gid             = <%= @gid %>
+<% if @incoming_chmod -%>
 incoming chmod  = <%= @incoming_chmod %>
+<% end -%>
+<% if @outgoing_chmod -%>
 outgoing chmod  = <%= @outgoing_chmod %>
+<% end -%>
 max connections = <%= @max_connections %>
 <% if Integer(@max_connections) > 0 -%>
 lock file       = <%= @lock_file %>


### PR DESCRIPTION
- added test and documentation

However. rsync also works with those parameters (incoming_chmod and outgoing_chmod) set to epmty string.
But in this case the configuration may confuse human readers.
