### PR TITLE
Allow multiple include or exclude patterns

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
     "xinetd": "git://github.com/ghoneycutt/puppet-xinetd"
+    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib"
   symlinks:
     "rsync": "#{source_dir}"

--- a/README.markdown
+++ b/README.markdown
@@ -27,8 +27,8 @@ get files via rsync
     $hardlinks  - if set, rsync will use '--hard-links'
     $copylinks  - if set, rsync will use '--copy-links'
     $times      - if set, rsycn will use '--times'
-    $include    - string to be included
-    $exclude    - string to be excluded
+    $include    - string or array of strings to be included
+    $exclude    - string or array of strings to be excluded
     $keyfile    - ssh key used to connect to remote host
     $timeout    - timeout in seconds, defaults to 900
     $execuser   - user to run the command (passed to exec)
@@ -57,7 +57,7 @@ put files via rsync
     $path    - path to copy to, defaults to $name
     $user    - username on remote system
     $purge   - if set, rsync will use '--delete'
-    $exlude  - string to be excluded
+    $exlude  - string or array of strings to be excluded
     $keyfile - path to ssh key used to connect to remote host, defaults to /home/${user}/.ssh/id_rsa
     $timeout - timeout in seconds, defaults to 900
 

--- a/manifests/get.pp
+++ b/manifests/get.pp
@@ -7,7 +7,8 @@
 #   $path    - path to copy to, defaults to $name
 #   $user    - username on remote system
 #   $purge   - if set, rsync will use '--delete'
-#   $exlude  - string to be excluded
+#   $exlude  - string or array of strings to be excluded
+#   $include - string or array of strings to be included
 #   $keyfile - path to ssh key used to connect to remote host, defaults to /home/${user}/.ssh/id_rsa
 #   $timeout - timeout in seconds, defaults to 900
 #   $onlyif  - Condition to run the rsync command
@@ -58,14 +59,16 @@ define rsync::get (
     $myPurge = ' --delete'
   }
 
-  # Not currently correct, there can be multiple --exclude arguments
   if $exclude {
-    $myExclude = " --exclude=${exclude}"
+    $excludeArray = any2array($exclude)
+    $joinedExclude = join($excludeArray, " --exclude=")
+    $myExclude = " --exclude=${joinedExclude}"
   }
 
-  # Not currently correct, there can be multiple --include arguments
   if $include {
-    $myInclude = " --include=${include}"
+    $includeArray = any2array($include)
+    $joinedInclude = join($includeArray, " --include=")
+    $myInclude = " --include=${joinedInclude}"
   }
 
   if $recursive {

--- a/manifests/put.pp
+++ b/manifests/put.pp
@@ -7,7 +7,7 @@
 #   $path    - path to copy to, defaults to $name
 #   $user    - username on remote system
 #   $purge   - if set, rsync will use '--delete'
-#   $exlude  - string to be excluded
+#   $exlude  - string or array of strings to be excluded
 #   $keyfile - path to ssh key used to connect to remote host, defaults to /home/${user}/.ssh/id_rsa
 #   $timeout - timeout in seconds, defaults to 900
 #
@@ -35,31 +35,33 @@ define rsync::put (
 ) {
 
   if $keyfile {
-    $Mykeyfile = $keyfile
+    $myKeyFile = $keyfile
   } else {
-    $Mykeyfile = "/home/${user}/.ssh/id_rsa"
+    $myKeyFile = "/home/${user}/.ssh/id_rsa"
   }
 
   if $user {
-    $MyUserOpt = "-e 'ssh -i ${Mykeyfile} -l ${user}' "
-    $MyUser = "${user}@"
+    $myUserOpt = "-e 'ssh -i ${myKeyFile} -l ${user}' "
+    $myUser = "${user}@"
   }
 
   if $purge {
-    $MyPurge = '--delete'
+    $myPurge = '--delete'
   }
 
   if $exclude {
-    $MyExclude = "--exclude=${exclude}"
+    $excludeArray = any2array($exclude)
+    $joinedExclude = join($excludeArray, " --exclude=")
+    $myExclude = " --exclude=${joinedExclude}"
   }
 
   if $path {
-    $MyPath = $path
+    $myPath = $path
   } else {
-    $MyPath = $name
+    $myPath = $name
   }
 
-  $rsync_options = "-a ${MyPurge} ${MyExclude} ${MyUserOpt}${source} ${MyUser}${MyPath}"
+  $rsync_options = "-a ${myPurge} ${myExclude} ${myUserOpt}${source} ${myUser}${myPath}"
 
   exec { "rsync ${name}":
     command => "rsync -q ${rsync_options}",

--- a/spec/defines/get_spec.rb
+++ b/spec/defines/get_spec.rb
@@ -98,6 +98,19 @@ describe 'rsync::get', :type => :define do
     }
   end
 
+  describe "when setting multiple exclude paths" do
+    let :params do
+      common_params.merge({ :exclude => ['/path/one/exclude/','/path/two/exclude/'] })
+    end
+
+    it {
+      should contain_exec("rsync foobar").with({
+        'command' => 'rsync -q -a --exclude=/path/one/exclude/ --exclude=/path/two/exclude/ example.com foobar',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a --exclude=/path/one/exclude/ --exclude=/path/two/exclude/ example.com foobar | wc -l` -gt 0",
+       })
+    }
+  end
+
   describe "when setting an include path" do
     let :params do
       common_params.merge({ :include => '/path/to/include/' })
@@ -107,6 +120,19 @@ describe 'rsync::get', :type => :define do
       should contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --include=/path/to/include/ example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --include=/path/to/include/ example.com foobar | wc -l` -gt 0",
+       })
+    }
+  end
+
+  describe "when setting multiple include paths" do
+    let :params do
+      common_params.merge({ :include => ['/path/one/include/','/path/two/include/'] })
+    end
+
+    it {
+      should contain_exec("rsync foobar").with({
+        'command' => 'rsync -q -a --include=/path/one/include/ --include=/path/two/include/ example.com foobar',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a --include=/path/one/include/ --include=/path/two/include/ example.com foobar | wc -l` -gt 0",
        })
     }
   end

--- a/spec/defines/put_spec.rb
+++ b/spec/defines/put_spec.rb
@@ -83,8 +83,21 @@ describe 'rsync::put', :type => :define do
 
     it {
       should contain_exec("rsync foobar").with({
-        'command' => 'rsync -q -a  --exclude=/path/to/exclude/ example.com foobar',
-        'onlyif'  => "test `rsync --dry-run --itemize-changes -a  --exclude=/path/to/exclude/ example.com foobar | wc -l` -gt 0",
+        'command' => 'rsync -q -a   --exclude=/path/to/exclude/ example.com foobar',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a   --exclude=/path/to/exclude/ example.com foobar | wc -l` -gt 0",
+       })
+    }
+  end
+
+  describe "when setting multiple exclude paths" do
+    let :params do
+      common_params.merge({ :exclude => ['/path/one/exclude/','/path/two/exclude/'] })
+    end
+
+    it {
+      should contain_exec("rsync foobar").with({
+        'command' => 'rsync -q -a   --exclude=/path/one/exclude/ --exclude=/path/two/exclude/ example.com foobar',
+        'onlyif'  => "test `rsync --dry-run --itemize-changes -a   --exclude=/path/one/exclude/ --exclude=/path/two/exclude/ example.com foobar | wc -l` -gt 0",
        })
     }
   end


### PR DESCRIPTION
Current implementation only allows for one include or exclude pattern with a comment mentioning this is wrong. This change should be backwards compatible allowing one or more patterns to be passed (either as a string or an array) and included in the final rsync command.
