### PR TITLE
Add support for the rsync option --ignore-times

### DIFF
--- a/manifests/get.pp
+++ b/manifests/get.pp
@@ -41,6 +41,7 @@ define rsync::get (
   $timeout    = '900',
   $execuser   = 'root',
   $chown      = undef,
+  $ignoretimes= undef,
   $onlyif     = undef,
 ) {
 
@@ -92,7 +93,11 @@ define rsync::get (
     $myChown = " --chown=${chown}"
   }
 
-  $rsync_options = "-a${myPurge}${myExclude}${myInclude}${myLinks}${myHardLinks}${myCopyLinks}${myTimes}${myRecursive}${myChown} ${myUser}${source} ${path}"
+  if $ignoretimes {
+    $myIgnoreTimes = ' --ignore-times'
+  }
+
+  $rsync_options = "-a${myPurge}${myExclude}${myInclude}${myLinks}${myHardLinks}${myCopyLinks}${myTimes}${myRecursive}${myChown}${myIgnoreTimes} ${myUser}${source} ${path}"
 
   if !$onlyif {
     $onlyif_real = "test `rsync --dry-run --itemize-changes ${rsync_options} | wc -l` -gt 0"


### PR DESCRIPTION
In some situations, relying on time and size is not appropriate. User
may want to decide himself, thanks to onlyif, if a file must be rsync'ed.
