### PR TITLE
Convert specs to RSpec 3.1.7 syntax with Transpec

### DIFF
--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -7,12 +7,12 @@ describe 'rsync::server', :type => :class do
 
   describe 'when using default params' do
     it {
-      should contain_class('xinetd')
-      should contain_xinetd__service('rsync').with({ 'bind' => '0.0.0.0' })
-      should_not contain_service('rsync')
-      should_not contain_file('/etc/rsync-motd')
-      should contain_file(fragment_file).with_content(/^use chroot\s*=\s*yes$/)
-      should contain_file(fragment_file).with_content(/^address\s*=\s*0.0.0.0$/)
+      is_expected.to contain_class('xinetd')
+      is_expected.to contain_xinetd__service('rsync').with({ 'bind' => '0.0.0.0' })
+      is_expected.not_to contain_service('rsync')
+      is_expected.not_to contain_file('/etc/rsync-motd')
+      is_expected.to contain_file(fragment_file).with_content(/^use chroot\s*=\s*yes$/)
+      is_expected.to contain_file(fragment_file).with_content(/^address\s*=\s*0.0.0.0$/)
     }
   end
 
@@ -22,9 +22,9 @@ describe 'rsync::server', :type => :class do
     end
 
     it {
-      should_not contain_class('xinetd')
-      should_not contain_xinetd__service('rsync')
-      should contain_service('rsync')
+      is_expected.not_to contain_class('xinetd')
+      is_expected.not_to contain_xinetd__service('rsync')
+      is_expected.to contain_service('rsync')
     }
   end
 
@@ -34,7 +34,7 @@ describe 'rsync::server', :type => :class do
     end
 
     it {
-      should contain_file('/etc/rsync-motd')
+      is_expected.to contain_file('/etc/rsync-motd')
     }
   end
 
@@ -44,7 +44,7 @@ describe 'rsync::server', :type => :class do
     end
 
     it {
-      should contain_file(fragment_file).with_content(/^use chroot\s*=\s*no$/)
+      is_expected.to contain_file(fragment_file).with_content(/^use chroot\s*=\s*no$/)
     }
   end
 
@@ -54,7 +54,7 @@ describe 'rsync::server', :type => :class do
     end
 
     it {
-      should contain_file(fragment_file).with_content(/^address\s*=\s*10.0.0.42$/)
+      is_expected.to contain_file(fragment_file).with_content(/^address\s*=\s*10.0.0.42$/)
     }
   end
 
@@ -64,7 +64,7 @@ describe 'rsync::server', :type => :class do
     end
 
     it {
-      should contain_file(fragment_file).with_content(/^uid\s*=\s*testuser$/)
+      is_expected.to contain_file(fragment_file).with_content(/^uid\s*=\s*testuser$/)
     }
   end
 
@@ -74,7 +74,7 @@ describe 'rsync::server', :type => :class do
     end
 
     it {
-      should contain_file(fragment_file).with_content(/^gid\s*=\s*testgroup$/)
+      is_expected.to contain_file(fragment_file).with_content(/^gid\s*=\s*testgroup$/)
     }
   end
 

--- a/spec/defines/get_spec.rb
+++ b/spec/defines/get_spec.rb
@@ -16,7 +16,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a example.com foobar | wc -l` -gt 0",
         'timeout' => '900',
@@ -30,7 +30,7 @@ describe 'rsync::get', :type => :define do
       common_params.merge( { :execuser => 'username' } )
     end
 
-    it{ should contain_exec("rsync foobar").with({ 'user' => 'username' }) }
+    it{ is_expected.to contain_exec("rsync foobar").with({ 'user' => 'username' }) }
   end
 
   describe "when setting the timeout" do
@@ -39,7 +39,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({ 'timeout' => '200' })
+      is_expected.to contain_exec("rsync foobar").with({ 'timeout' => '200' })
     }
   end
 
@@ -49,7 +49,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a -e \'ssh -i /home/mr_baz/.ssh/id_rsa -l mr_baz\' mr_baz@example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a -e \'ssh -i /home/mr_baz/.ssh/id_rsa -l mr_baz\' mr_baz@example.com foobar | wc -l` -gt 0",
       })
@@ -62,7 +62,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a example.com foobar | wc -l` -gt 0",
       })
@@ -78,7 +78,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a -e \'ssh -i /path/to/keyfile -l mr_baz\' mr_baz@example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a -e \'ssh -i /path/to/keyfile -l mr_baz\' mr_baz@example.com foobar | wc -l` -gt 0",
        })
@@ -91,7 +91,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --exclude=/path/to/exclude/ example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --exclude=/path/to/exclude/ example.com foobar | wc -l` -gt 0",
        })
@@ -104,7 +104,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --exclude=logs/ --exclude=tmp/ example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --exclude=logs/ --exclude=tmp/ example.com foobar | wc -l` -gt 0",
        })
@@ -117,7 +117,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --include=/path/to/include/ example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --include=/path/to/include/ example.com foobar | wc -l` -gt 0",
        })
@@ -130,7 +130,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --include=htdocs/ --include=cache/ example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --include=htdocs/ --include=cache/ example.com foobar | wc -l` -gt 0",
        })
@@ -143,7 +143,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --delete example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --delete example.com foobar | wc -l` -gt 0"
        })
@@ -156,7 +156,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a -r example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a -r example.com foobar | wc -l` -gt 0"
        })
@@ -169,7 +169,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --links example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --links example.com foobar | wc -l` -gt 0"
        })
@@ -182,7 +182,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -rlpcgoD example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -rlpcgoD example.com foobar | wc -l` -gt 0"
        })
@@ -195,7 +195,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --hard-links example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --hard-links example.com foobar | wc -l` -gt 0"
        })
@@ -208,7 +208,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --copy-links example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --copy-links example.com foobar | wc -l` -gt 0"
        })
@@ -221,7 +221,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --times example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --times example.com foobar | wc -l` -gt 0"
        })
@@ -234,7 +234,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a example.com barfoo',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a example.com barfoo | wc -l` -gt 0"
        })
@@ -247,7 +247,7 @@ describe 'rsync::get', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a example.com foobar',
         'onlyif'  => "false"
        })

--- a/spec/defines/put_spec.rb
+++ b/spec/defines/put_spec.rb
@@ -16,7 +16,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a example.com foobar | wc -l` -gt 0",
         'timeout' => '900'
@@ -30,7 +30,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({ 'timeout' => '200' })
+      is_expected.to contain_exec("rsync foobar").with({ 'timeout' => '200' })
     }
   end
 
@@ -40,7 +40,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a -e \'ssh -i /home/mr_baz/.ssh/id_rsa -l mr_baz\' example.com mr_baz@foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a -e \'ssh -i /home/mr_baz/.ssh/id_rsa -l mr_baz\' example.com mr_baz@foobar | wc -l` -gt 0",
       })
@@ -53,7 +53,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a example.com foobar | wc -l` -gt 0",
       })
@@ -69,7 +69,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a -e \'ssh -i /path/to/keyfile -l mr_baz\' example.com mr_baz@foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a -e \'ssh -i /path/to/keyfile -l mr_baz\' example.com mr_baz@foobar | wc -l` -gt 0",
        })
@@ -82,7 +82,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --exclude=/path/to/exclude/ example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --exclude=/path/to/exclude/ example.com foobar | wc -l` -gt 0",
        })
@@ -95,7 +95,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --exclude=logs/ --exclude=tmp/ example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --exclude=logs/ --exclude=tmp/ example.com foobar | wc -l` -gt 0",
        })
@@ -108,7 +108,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --include=/path/to/include/ example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --include=/path/to/include/ example.com foobar | wc -l` -gt 0",
        })
@@ -121,7 +121,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --include=htdocs/ --include=cache/ example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --include=htdocs/ --include=cache/ example.com foobar | wc -l` -gt 0",
        })
@@ -134,7 +134,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a --delete example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a --delete example.com foobar | wc -l` -gt 0"
        })
@@ -147,7 +147,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -rlpcgoD example.com foobar',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -rlpcgoD example.com foobar | wc -l` -gt 0"
        })
@@ -160,7 +160,7 @@ describe 'rsync::put', :type => :define do
     end
 
     it {
-      should contain_exec("rsync foobar").with({
+      is_expected.to contain_exec("rsync foobar").with({
         'command' => 'rsync -q -a example.com barfoo',
         'onlyif'  => "test `rsync --dry-run --itemize-changes -a example.com barfoo | wc -l` -gt 0"
        })

--- a/spec/defines/server_module_spec.rb
+++ b/spec/defines/server_module_spec.rb
@@ -22,29 +22,29 @@ describe 'rsync::server::module', :type => :define do
   end
 
   describe "when using default class paramaters" do
-    it { should contain_file(fragment_file).with_content(/^\[ foobar \]$/) }
-    it { should contain_file(fragment_file).with_content(/^path\s*=\s*\/some\/path$/) }
-    it { should contain_file(fragment_file).with_content(/^read only\s*=\s*yes$/) }
-    it { should contain_file(fragment_file).with_content(/^write only\s*=\s*no$/) }
-    it { should contain_file(fragment_file).with_content(/^list\s*=\s*yes$/) }
-    it { should contain_file(fragment_file).with_content(/^uid\s*=\s*0$/) }
-    it { should contain_file(fragment_file).with_content(/^gid\s*=\s*0$/) }
-    it { should contain_file(fragment_file).with_content(/^incoming chmod\s*=\s*0644$/) }
-    it { should contain_file(fragment_file).with_content(/^outgoing chmod\s*=\s*0644$/) }
-    it { should contain_file(fragment_file).with_content(/^max connections\s*=\s*0$/) }
-    it { should_not contain_file(fragment_file).with_content(/^lock file\s*=.*$/) }
-    it { should_not contain_file(fragment_file).with_content(/^secrets file\s*=.*$/) }
-    it { should_not contain_file(fragment_file).with_content(/^auth users\s*=.*$/) }
-    it { should_not contain_file(fragment_file).with_content(/^hosts allow\s*=.*$/) }
-    it { should_not contain_file(fragment_file).with_content(/^hosts deny\s*=.*$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^\[ foobar \]$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^path\s*=\s*\/some\/path$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^read only\s*=\s*yes$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^write only\s*=\s*no$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^list\s*=\s*yes$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^uid\s*=\s*0$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^gid\s*=\s*0$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^incoming chmod\s*=\s*0644$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^outgoing chmod\s*=\s*0644$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^max connections\s*=\s*0$/) }
+    it { is_expected.not_to contain_file(fragment_file).with_content(/^lock file\s*=.*$/) }
+    it { is_expected.not_to contain_file(fragment_file).with_content(/^secrets file\s*=.*$/) }
+    it { is_expected.not_to contain_file(fragment_file).with_content(/^auth users\s*=.*$/) }
+    it { is_expected.not_to contain_file(fragment_file).with_content(/^hosts allow\s*=.*$/) }
+    it { is_expected.not_to contain_file(fragment_file).with_content(/^hosts deny\s*=.*$/) }
   end
 
   describe "when overriding max connections" do
     let :params do
       mandatory_params.merge({ :max_connections => 1 })
     end
-    it { should contain_file(fragment_file).with_content(/^max connections\s*=\s*1$/) }
-    it { should contain_file(fragment_file).with_content(/^lock file\s*=\s*\/var\/run\/rsyncd\.lock$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^max connections\s*=\s*1$/) }
+    it { is_expected.to contain_file(fragment_file).with_content(/^lock file\s*=\s*\/var\/run\/rsyncd\.lock$/) }
   end
 
   {
@@ -64,7 +64,7 @@ describe 'rsync::server::module', :type => :define do
       let :params do
         mandatory_params.merge({ k => v })
       end
-      it { should contain_file(fragment_file).with_content(/^#{k.to_s.gsub('_', ' ')}\s*=\s*#{Array(v).join(' ')}$/)}
+      it { is_expected.to contain_file(fragment_file).with_content(/^#{k.to_s.gsub('_', ' ')}\s*=\s*#{Array(v).join(' ')}$/)}
     end
   end
 
@@ -72,7 +72,7 @@ describe 'rsync::server::module', :type => :define do
     let :params do
       mandatory_params.merge({ :auth_users     => ['me', 'you', 'them'] })
     end
-    it { should contain_file(fragment_file).with_content(/^auth users\s*=\s*me, you, them$/)}
+    it { is_expected.to contain_file(fragment_file).with_content(/^auth users\s*=\s*me, you, them$/)}
   end
 
 end


### PR DESCRIPTION
This conversion is done by Transpec 3.0.3 with the following command:
    transpec
- 50 conversions
  from: it { should ... }
    to: it { is_expected.to ... }
- 9 conversions
  from: it { should_not ... }
    to: it { is_expected.not_to ... }

this still leaves us with 63 deprecation warnings
