### PR TITLE
manage install of rsync package as a parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,6 +9,7 @@ Manage rsync package
 
 ## Parameters: ##
     $package_ensure - any of the valid values for the package resource: present, absent, purged, held, latest
+    $manage_package - setting this to false stops the rsync package resource from being managed
 
 ## Sample Usage: ##
     class { 'rsync': package_ensure => 'latest' }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,9 +2,14 @@
 #
 # This module manages rsync
 #
-class rsync($package_ensure = 'installed') {
+class rsync(
+  $package_ensure    = 'installed',
+  $manage_package    = true
+) {
 
-  package { 'rsync':
-    ensure => $package_ensure,
-  } -> Rsync::Get<| |>
+  if $manage_package {
+    package { 'rsync':
+      ensure => $package_ensure,
+    } -> Rsync::Get<| |>
+  }
 }


### PR DESCRIPTION
A new manage_package paramenter is introduced.  When set to false, the
rysnc package resource is not managed.  This is useful when the rsync
package is managed from another module.  Without this parameter,
attempting to manage the rsync package resource would result in a
duplicate resource error.