### PR TITLE
Update server.pp to work with SUSE OSs

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -17,7 +17,12 @@ class rsync::server(
 
   $conf_file = $::osfamily ? {
     'Debian' => '/etc/rsyncd.conf',
+    'suse'   => '/etc/rsyncd.conf',
     default  => '/etc/rsync.conf',
+  }
+  $servicename = $::osfamily ? {
+    'suse'  => 'rsyncd',
+    default => 'rsync',
   }
 
   if $use_xinetd {
@@ -30,7 +35,7 @@ class rsync::server(
       require     => Package['rsync'],
     }
   } else {
-    service { 'rsync':
+    service { $servicename:
       ensure     => running,
       enable     => true,
       hasstatus  => true,


### PR DESCRIPTION
added config and service name settings for SUSE based OSs. (there will still be problems if $use_xinetd is true.

This is my first attempt at a githib pull request, so please point me in the direction of some docs if I've done this incorrectly. 