### PR TITLE
Pin rspec version to 3.1.0 (rspec/rspec-core#1864)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem 'rspec', '~> 3.1.0'
 gem 'puppetlabs_spec_helper'
 if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion,  :require => false


### PR DESCRIPTION
PuppetLabs JIRA MODULES-1859

Make rspec tests run on EL6 and Ruby 1.8.7