### PR TITLE
Fix stdlib dependency version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-rsync",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">=2.2.1"},
+    {"name":"puppetlabs/stdlib","version_requirement":">=4.2.0"},
     {"name":"puppetlabs/xinetd","version_requirement":">=1.1.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.1"}
   ]


### PR DESCRIPTION
delete_undef_values() was added in puppetlabs-stdlib 4.2.0