### PR TITLE
switch to dport

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -29,7 +29,7 @@ class rsync::server(
     include xinetd
     xinetd::service { 'rsync':
       bind        => $address,
-      port        => '873',
+      dport       => '873',
       server      => '/usr/bin/rsync',
       server_args => "--daemon --config ${conf_file}",
       require     => Package['rsync'],


### PR DESCRIPTION
The current firewall module complains about the usage of port:

Warning: port is deprecated and will be removed. Use dport and/or sport instead.