### PR TITLE
Change default chmod behaviour, update xinetd dependency.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    "xinetd": "git://github.com/ghoneycutt/puppet-xinetd"
+    "xinetd": "git://github.com/puppetlabs/puppetlabs-xinetd"
     "concat": "git://github.com/puppetlabs/puppetlabs-concat"
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib"
   symlinks:

--- a/README.markdown
+++ b/README.markdown
@@ -90,8 +90,8 @@ sets up a rsync server
     $list            - yes||no, defaults to no
     $uid             - uid of rsync server, defaults to 0
     $gid             - gid of rsync server, defaults to 0
-    $incoming_chmod  - incoming file mode, defaults to 644
-    $outgoing_chmod  - outgoing file mode, defaults to 644
+    $incoming_chmod  - incoming file mode, defaults to no chmod
+    $outgoing_chmod  - outgoing file mode, defaults to no chmod
     $max_connections - maximum number of simultaneous connections allowed, defaults to 0
     $lock_file       - file used to support the max connections parameter, defaults to /var/run/rsyncd.lock only needed if max_connections > 0
     $secrets_file    - path to the file that contains the username:password pairs used for authenticating this module
@@ -115,15 +115,6 @@ sets up a rsync server
       require => File[$base],
     }
 
-To disable default values for ``incoming_chmod`` and ``outgoing_chmod``, and
-do not add empty values to the resulting config, set both values to ``false``
-
-    rsync::server::module { 'repo':
-      path           => $base,
-      incoming_chmod => false,
-      outgoing_chmod => false,
-      require        => File[$base],
-    }
 
 # Configuring via Hiera #
 ``rsync::put``, ``rsync::get``, and ``rsync::server::module`` resources can be
@@ -132,8 +123,8 @@ configured using Hiera hashes. For example:
     rsync::server::modules:
       myrepo:
         path: /mypath
-        incoming_chmod: false
-        outgoing_chmod: false
+        incoming_chmod: 755
+        outgoing_chmod: 755
       myotherrepo:
         path: /otherpath
         read_only: false

--- a/manifests/server/module.pp
+++ b/manifests/server/module.pp
@@ -10,8 +10,8 @@
 #   $list             - yes||no, defaults to yes
 #   $uid              - uid of rsync server, defaults to 0
 #   $gid              - gid of rsync server, defaults to 0
-#   $incoming_chmod   - incoming file mode, defaults to 0644
-#   $outgoing_chmod   - outgoing file mode, defaults to 0644
+#   $incoming_chmod   - incoming file mode, defaults to no chmod
+#   $outgoing_chmod   - outgoing file mode, defaults to no chmod
 #   $max_connections  - maximum number of simultaneous connections allowed, defaults to 0
 #   $lock_file        - file used to support the max connections parameter, defaults to /var/run/rsyncd.lock
 #    only needed if max_connections > 0
@@ -19,10 +19,10 @@
 #   $auth_users       - list of usernames that will be allowed to connect to this module (must be undef or an array)
 #   $hosts_allow      - list of patterns allowed to connect to this module (man 5 rsyncd.conf for details, must be undef or an array)
 #   $hosts_deny       - list of patterns allowed to connect to this module (man 5 rsyncd.conf for details, must be undef or an array)
-#   $transfer_logging - parameter enables per-file logging of downloads and 
+#   $transfer_logging - parameter enables per-file logging of downloads and
 #    uploads in a format somewhat similar to that used by ftp daemons.
-#   $log_format       - This parameter allows you to specify the format used 
-#    for logging file transfers when transfer logging is enabled. See the 
+#   $log_format       - This parameter allows you to specify the format used
+#    for logging file transfers when transfer logging is enabled. See the
 #    rsyncd.conf documentation for more details.
 #   $refuse_options   - list of rsync command line options that will be refused by your rsync daemon.
 #
@@ -47,8 +47,8 @@ define rsync::server::module (
   $list             = 'yes',
   $uid              = '0',
   $gid              = '0',
-  $incoming_chmod   = '0644',
-  $outgoing_chmod   = '0644',
+  $incoming_chmod   = undef,
+  $outgoing_chmod   = undef,
   $max_connections  = '0',
   $lock_file        = '/var/run/rsyncd.lock',
   $secrets_file     = undef,

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 describe 'rsync::server', :type => :class do
   let(:facts) do
     {
+      :osfamily => 'Debian',
       :concat_basedir => '/dne'
     }
   end
@@ -90,7 +91,7 @@ describe 'rsync::server', :type => :class do
     end
     let(:facts) do
       {
-        :osfamily => 'SuSE',
+        :osfamily => 'Suse',
         :concat_basedir => '/dne',
       }
     end

--- a/spec/defines/server_module_spec.rb
+++ b/spec/defines/server_module_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'rsync::server::module', :type => :define do
   let :facts do
     {
+      :osfamily => 'Debian',
       :concat_basedir => '/dne'
     }
   end
@@ -35,8 +36,8 @@ describe 'rsync::server::module', :type => :define do
     it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^list\s*=\s*yes$/) }
     it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^uid\s*=\s*0$/) }
     it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^gid\s*=\s*0$/) }
-    it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^incoming chmod\s*=\s*0644$/) }
-    it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^outgoing chmod\s*=\s*0644$/) }
+    it { is_expected.not_to contain_concat__fragment(fragment_name).with_content(/^incoming chmod.*$/) }
+    it { is_expected.not_to contain_concat__fragment(fragment_name).with_content(/^outgoing chmod.*$/) }
     it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^max connections\s*=\s*0$/) }
     it { is_expected.not_to contain_concat__fragment(fragment_name).with_content(/^lock file\s*=.*$/) }
     it { is_expected.not_to contain_concat__fragment(fragment_name).with_content(/^secrets file\s*=.*$/) }
@@ -56,14 +57,14 @@ describe 'rsync::server::module', :type => :define do
     it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^lock file\s*=\s*\/var\/run\/rsyncd\.lock$/) }
   end
 
-  describe "when setting incoming chmod to false" do
+  describe "when setting chmods to 755" do
     let :params do
-      mandatory_params.merge({:incoming_chmod => false,
-                              :outgoing_chmod => false,
+      mandatory_params.merge({:incoming_chmod => '0755',
+                              :outgoing_chmod => '0755',
       })
     end
-    it { is_expected.not_to contain_file(fragment_name).with_content(/^incoming chmod.*$/) }
-    it { is_expected.not_to contain_file(fragment_name).with_content(/^outgoing chmod.*$/) }
+    it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^incoming chmod\s+=\s+0755$/) }
+    it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^outgoing chmod\s+=\s+0755$/) }
   end
 
   {
@@ -98,4 +99,3 @@ describe 'rsync::server::module', :type => :define do
   end
 
 end
-


### PR DESCRIPTION
Until after v3.0.7, rsync's chmod directives completely ignored octal chmods, only paying attention to "Du+rwx"-style specifiers. When upgrading from rsync v3.0.7 to v3.0.10, I hit an issue wherein rsynced directories became inaccessible because the 644 permissions are applied to all files and directories, and directories lacked executable bits. Rather than change this chmod to a comprehensive "Du+rwx,go+rx,Fu+rwx,go+r", I think it makes sense to disable the chmod by default and allow users to configure their own chmods per-module and otherwise maintain the original modes set on files.

This PR also updates the fixtures to use the now-puppetlabs-maintained xinetd repository and updates test facts accordingly. 