### PR TITLE
Ubuntu does not accept space between -e '...' and user

### DIFF
--- a/manifests/get.pp
+++ b/manifests/get.pp
@@ -54,7 +54,7 @@ define rsync::get (
   }
 
   if $user {
-    $myUser = "-e 'ssh -i ${mykeyfile} -l ${user}' ${user}@"
+    $myUser = "-e 'ssh -i ${mykeyfile} -l ${user}'${user}@"
   } else {
     $myUser = undef
   }


### PR DESCRIPTION
	modified:   get.pp