### PR TITLE
Allow configurable syslog facility

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -14,6 +14,7 @@ class rsync::server(
   $uid        = 'nobody',
   $gid        = 'nobody',
   $modules    = {},
+  $syslog_facility = 'local3',
 ) inherits rsync {
 
   $conf_file = $::osfamily ? {

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -6,7 +6,7 @@ uid = <%= @uid %>
 gid = <%= @gid %>
 use chroot = <%= @use_chroot %>
 log format = %t %a %m %f %b
-syslog facility = local3
+syslog facility = <%= @syslog_facility %> 
 timeout = 300
 address = <%= @address %>
 <% if @motd_file != 'UNSET' -%>


### PR DESCRIPTION
Local3 is an odd hard-coded default; it's certainly not what rsync on Ubuntu would use if unconfigured (daemon), so at least being able to configure it is a good start.  It might be nice to also have a different actual default value per-OS, but for now just being able to set it is sufficient.