### PR TITLE
Add nice and ionice to rsync server

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -8,8 +8,8 @@
 #
 class rsync::server(
   $use_xinetd = true,
-  $address    = '0.0.0.0',
-  $motd_file  = 'UNSET',
+  $address    = undef,
+  $motd_file  = undef,
   $use_chroot = 'yes',
   $uid        = 'nobody',
   $gid        = 'nobody',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -13,6 +13,8 @@ class rsync::server(
   $use_chroot = 'yes',
   $uid        = 'nobody',
   $gid        = 'nobody',
+  $nice       = '0',
+  $ionice     = '-c2',
   $modules    = {},
 ) inherits rsync {
 
@@ -35,8 +37,9 @@ class rsync::server(
     xinetd::service { 'rsync':
       bind        => $address,
       port        => '873',
-      server      => '/usr/bin/rsync',
-      server_args => "--daemon --config ${conf_file}",
+      nice        => $nice,
+      server      => '/usr/bin/ionice',
+      server_args => "${ionice} /usr/bin/rsync --daemon --config ${conf_file}",
       require     => Package['rsync'],
     }
   } else {
@@ -50,7 +53,7 @@ class rsync::server(
 
     if ( $::osfamily == 'Debian' ) {
       file { '/etc/default/rsync':
-        source => 'puppet:///modules/rsync/defaults',
+        content => template('rsync/defaults.erb'),
         notify => Service['rsync'],
       }
     }

--- a/templates/defaults.erb
+++ b/templates/defaults.erb
@@ -15,7 +15,7 @@ RSYNC_ENABLE=true
 #          using a remote shell. When using a different file for
 #          rsync you might want to symlink /etc/rsyncd.conf to
 #          that file.
-# RSYNC_CONFIG_FILE=
+RSYNC_CONFIG_FILE=<%= @conf_file %>
 
 # what extra options to give rsync --daemon?
 #  that excludes the --daemon; that's always done in the init.d script
@@ -28,7 +28,7 @@ RSYNC_OPTS=''
 #  the rsync daemon can impact performance due to much I/O and CPU usage,
 #  so you may want to run it at a nicer priority than the default priority.
 #  Allowed values are 0 - 19 inclusive; 10 is a reasonable value.
-RSYNC_NICE=''
+RSYNC_NICE='<%= @nice %>'
 
 # run rsyncd with ionice?
 #  "ionice" does for IO load what "nice" does for CPU load.
@@ -37,7 +37,7 @@ RSYNC_NICE=''
 #  See the manpage for ionice for allowed options.
 #  -c3 is recommended, this will run rsync IO at "idle" priority. Uncomment
 #  the next line to activate this.
-# RSYNC_IONICE='-c3'
+RSYNC_IONICE='<%= @ionice %>'
 
 # Don't forget to create an appropriate config file,
 # else the daemon will not start.

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -8,7 +8,9 @@ use chroot = <%= @use_chroot %>
 log format = %t %a %m %f %b
 syslog facility = local3
 timeout = 300
+<% if @address -%>
 address = <%= @address %>
-<% if @motd_file != 'UNSET' -%>
+<% end -%>
+<% if @motd_file -%>
 motd file = <%= @motd_file %>
 <% end -%>


### PR DESCRIPTION
I needed access to nice and ionice levels on my Debian rsync server.
Templatized the defaults file so that these were accessible. Also
added nice to xinetd service and changed the server to ionice and the
server args to the ionice level followed by the rsync path and
previously existing arguments.