### PR TITLE
Fixes for server header

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -8,8 +8,8 @@
 #
 class rsync::server(
   $use_xinetd = true,
-  $address    = '0.0.0.0',
-  $motd_file  = 'UNSET',
+  $address    = undef,
+  $motd_file  = undef,
   $use_chroot = 'yes',
   $uid        = 'nobody',
   $gid        = 'nobody',

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -8,7 +8,9 @@ use chroot = <%= @use_chroot %>
 log format = %t %a %m %f %b
 syslog facility = local3
 timeout = 300
+<% if @address -%>
 address = <%= @address %>
-<% if @motd_file != 'UNSET' -%>
+<% end -%>
+<% if @motd_file -%>
 motd file = <%= @motd_file %>
 <% end -%>


### PR DESCRIPTION
Allow address to be undef so that rsyncd can listen on all interfaces
useful for IPv4/IPv6 dual stack boxes where you want the daemon to
listen on both simultaneously. By setting address to :: the server
was only listening on IPv6 but setting it to 0.0.0.0 it was only
listening on IPv4. Leaving it out of the config makes the daemon
listen on all interfaces at startup.