### PR TITLE
Add dont_compress to server module

### DIFF
--- a/manifests/server/module.pp
+++ b/manifests/server/module.pp
@@ -19,10 +19,10 @@
 #   $auth_users       - list of usernames that will be allowed to connect to this module (must be undef or an array)
 #   $hosts_allow      - list of patterns allowed to connect to this module (man 5 rsyncd.conf for details, must be undef or an array)
 #   $hosts_deny       - list of patterns allowed to connect to this module (man 5 rsyncd.conf for details, must be undef or an array)
-#   $transfer_logging - parameter enables per-file logging of downloads and 
+#   $transfer_logging - parameter enables per-file logging of downloads and
 #    uploads in a format somewhat similar to that used by ftp daemons.
-#   $log_format       - This parameter allows you to specify the format used 
-#    for logging file transfers when transfer logging is enabled. See the 
+#   $log_format       - This parameter allows you to specify the format used
+#    for logging file transfers when transfer logging is enabled. See the
 #    rsyncd.conf documentation for more details.
 #   $refuse_options   - list of rsync command line options that will be refused by your rsync daemon.
 #
@@ -53,6 +53,7 @@ define rsync::server::module (
   $lock_file          = '/var/run/rsyncd.lock',
   $secrets_file       = undef,
   $exclude            = undef,
+  $dont_compress      = undef,
   $auth_users         = undef,
   $hosts_allow        = undef,
   $hosts_deny         = undef,

--- a/templates/module.erb
+++ b/templates/module.erb
@@ -36,6 +36,9 @@ hosts deny         = <%= Array(@hosts_deny).join(' ')%>
 <% if @exclude -%>
 exclude            = <%= Array(@exclude).join(' ')%>
 <% end -%>
+<% if @dont_compress -%>
+dont compress      = <%= Array(@dont_compress).join(' ')%>
+<% end -%>
 <% if @transfer_logging -%>
 transfer logging   = <%= @transfer_logging %>
 <% end -%>


### PR DESCRIPTION
Allows rsync to skip compression on file types that don't compress
well such as already compressed files and binary files.