### PR TITLE
fix dependency for puppetlabs-xinetd

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=4.2.0 <5.0.0"},
-    {"name":"puppetlabs/xinetd","version_requirement":">=1.1.0"},
+    {"name":"puppetlabs/xinetd","version_requirement":">=1.1.0 <3.0.0 "},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 <5.0.0"}
   ]
 }


### PR DESCRIPTION
test were failing with:
 (WARN) dependencies: Dependency puppetlabs/xinetd has an open ended dependency version requirement >=1.1.0