### PR TITLE
fix redirects during fixtures download

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,10 +1,7 @@
 fixtures:
   repositories:
-    xinetd:
-      repo: 'https://www.github.com/puppetlabs/puppetlabs-xinetd'
-    concat:
-      repo: 'https://www.github.com/puppetlabs/puppetlabs-concat'
-    stdlib:
-      repo: 'https://www.github.com/puppetlabs/puppetlabs-stdlib'
+    xinetd: 'https://github.com/puppetlabs/puppetlabs-xinetd.git'
+    concat: 'https://github.com/puppetlabs/puppetlabs-concat.git'
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
   symlinks:
     "rsync": "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=4.2.0 <5.0.0"},
-    {"name":"puppetlabs/xinetd","version_requirement":">=1.1.0"},
+    {"name":"puppetlabs/xinetd","version_requirement":">=1.1.0 < 4.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 <5.0.0"}
   ]
 }


### PR DESCRIPTION
the old URLs redirected to the github repos:
warning: redirecting to https://github.com/puppetlabs/puppetlabs-xinetd.git/
warning: redirecting to https://github.com/puppetlabs/puppetlabs-concat.git/
warning: redirecting to https://github.com/puppetlabs/puppetlabs-stdlib.git/

We can use the direct URLs here to make less HTTP connections