### PR TITLE
support for 'reverse lookup' and 'log file'

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,12 +7,14 @@
 #   class rsync
 #
 class rsync::server(
-  $use_xinetd = true,
-  $address    = '0.0.0.0',
-  $motd_file  = 'UNSET',
-  $use_chroot = 'yes',
-  $uid        = 'nobody',
-  $gid        = 'nobody',
+  $use_xinetd     = true,
+  $address        = '0.0.0.0',
+  $motd_file      = 'UNSET',
+  $use_chroot     = 'yes',
+  $uid            = 'nobody',
+  $gid            = 'nobody',
+  $log_file       = undef,
+  $reverse_lookup = undef,
   $modules    = {},
 ) inherits rsync {
 

--- a/manifests/server/module.pp
+++ b/manifests/server/module.pp
@@ -25,6 +25,8 @@
 #    for logging file transfers when transfer logging is enabled. See the 
 #    rsyncd.conf documentation for more details.
 #   $refuse_options   - list of rsync command line options that will be refused by your rsync daemon.
+#   $log_file         - filename of logfile, logs will be written to this file instead of to syslog
+#   $reverse_lookup   - yes||no, if omitted then the rsync default is used
 #
 #   sets up an rsync server
 #
@@ -59,7 +61,9 @@ define rsync::server::module (
   $transfer_logging   = undef,
   $log_format         = undef,
   $refuse_options     = undef,
-  $ignore_nonreadable = undef)  {
+  $ignore_nonreadable = undef,
+  $log_file           = undef,
+  $reverse_lookup     = undef)  {
 
   concat::fragment { "frag-${name}":
     content => template('rsync/module.erb'),

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -6,9 +6,16 @@ uid = <%= @uid %>
 gid = <%= @gid %>
 use chroot = <%= @use_chroot %>
 log format = %t %a %m %f %b
+<% if @log_file -%>
+log file = <%= @log_file %>
+<% else %>
 syslog facility = local3
+<% end -%>
 timeout = 300
 address = <%= @address %>
 <% if @motd_file != 'UNSET' -%>
 motd file = <%= @motd_file %>
+<% end -%>
+<% if @reverse_lookup -%>
+reverse lookup = <%= @reverse_lookup %>
 <% end -%>

--- a/templates/module.erb
+++ b/templates/module.erb
@@ -48,3 +48,9 @@ refuse options     = <%= Array(@refuse_options).join(' ')%>
 <% if @ignore_nonreadable -%>
 ignore nonreadable = <%= @ignore_nonreadable %>
 <% end -%>
+<% if @log_file -%>
+log_file = <%= @log_file %>
+<% end -%>
+<% if @reverse_lookup -%>
+reverse lookup = <%= @reverse_lookup %>
+<% end -%>


### PR DESCRIPTION
For both 'reverse lookup' and 'log file' I assume that if people omit one of these settings they don't want them in their config file and fallback to rsync defaults or to the defaults of this module (in case of syslog)
"log file" and "reverse lookup" are added to both server.pp and module.pp as serveral combinations of these settings in the global and module section are possible.