### PR TITLE
remove default value for keyfile: ${user} is the remote user, not local

### DIFF
--- a/manifests/get.pp
+++ b/manifests/get.pp
@@ -55,13 +55,13 @@ define rsync::get (
 ) {
 
   if $keyfile {
-    $mykeyfile = $keyfile
+    $mykeyfile = "-i $keyfile"
   } else {
-    $mykeyfile = "/home/${user}/.ssh/id_rsa"
+    $mykeyfile = ""
   }
 
   if $user {
-    $myuser = "-e 'ssh -i ${mykeyfile} -l ${user}' ${user}@"
+    $myuser = "-e 'ssh ${mykeyfile} -l ${user}' ${user}@"
   } else {
     $myuser = undef
   }

--- a/manifests/put.pp
+++ b/manifests/put.pp
@@ -40,13 +40,13 @@ define rsync::put (
 ) {
 
   if $keyfile {
-    $mykeyfile = $keyfile
+    $mykeyfile = "-i $keyfile"
   } else {
-    $mykeyfile = "/home/${user}/.ssh/id_rsa"
+    $mykeyfile = ""
   }
 
   if $user {
-    $myuseropt = "-e 'ssh -i ${mykeyfile} -l ${user}'"
+    $myuseropt = "-e 'ssh ${mykeyfile} -l ${user}'"
     $myuser = "${user}@"
   } else {
     $myuseropt = undef


### PR DESCRIPTION
/home/${user}/.ssh/id_rsa may not exist if $user does not exist locally.
It could also not be the right choice, depending on ssh configuration and $execuser.
If no key file is specified, let ssh find the right one.
