### PR TITLE
Fix bugs in module.erb

### DIFF
--- a/templates/module.erb
+++ b/templates/module.erb
@@ -65,9 +65,6 @@ include            = <%= Array(@include).join(' ')%>
 <% if @include_from -%>
 include from       = <%= @include_from%>
 <% end -%>
-<% if @exclude -%>
-exclude            = <%= Array(@exclude).join(' ')%>
-<% end -%>
 <% if @exclude_from -%>
 exclude from       = <%= @exclude_from%>
 <% end -%>

--- a/templates/module.erb
+++ b/templates/module.erb
@@ -1,6 +1,3 @@
-# This file is being maintained by Puppet.
-# DO NOT EDIT
-
 [ <%= @name %> ]
 path               = <%= @path %>
 read only          = <%= @read_only %>
@@ -77,3 +74,4 @@ exclude from       = <%= @exclude_from%>
 <% if @dont_compress -%>
 dont compress      = <%= Array(@dont_compress).join(' ')%>
 <% end -%>
+


### PR DESCRIPTION
This PR fixes two minor bugs in the module.erb:

1. The header isn't needed for each module. The header create by the server.pp (https://github.com/puppetlabs/puppetlabs-rsync/blob/447685f915b78fef86a693685f7e49e21ff9c998/manifests/server.pp#L82) class is enough.
2. There is an duplicate `exclude` parameter