### PR TITLE
Use absolute paths when including

### DIFF
--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,1 +1,1 @@
-include rsync
+include ::rsync

--- a/examples/repo.pp
+++ b/examples/repo.pp
@@ -1,1 +1,1 @@
-include rsync::repo
+include ::rsync::repo

--- a/examples/server_with_motd.pp
+++ b/examples/server_with_motd.pp
@@ -1,3 +1,3 @@
-class { 'rsync::server':
+class { '::rsync::server':
   motd_file => '/etc/rsync-motd',
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -7,7 +7,7 @@
 #
 class rsync::repo {
 
-  include rsync::server
+  include ::rsync::server
 
   $base = '/data/rsync'
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -40,7 +40,7 @@ class rsync::server(
   }
 
   if $use_xinetd {
-    include xinetd
+    include ::xinetd
     xinetd::service { 'rsync':
       bind        => $address,
       port        => '873',


### PR DESCRIPTION
This is to avoid a puppet-lint warning (relative_classname_inclusion)