### PR TITLE
Add option to change pid_file setting

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -266,6 +266,10 @@ Rsync comment.
 
 File containing motd info.
 
+##### `pid_file`
+
+PID file. Defaults to /var/run/rsyncd.pid. The pid file parameter won't be applied if set to "UNSET"; rsyncd will not use a PID file in this case.
+
 ##### `read_only`
 
 yes||no 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -10,6 +10,7 @@ class rsync::server(
   $use_xinetd = true,
   $address    = '0.0.0.0',
   $motd_file  = 'UNSET',
+  Variant[Enum['UNSET'], Stdlib::Absolutepath] $pid_file = '/var/run/rsyncd.pid',
   $use_chroot = 'yes',
   $uid        = 'nobody',
   $gid        = 'nobody',

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -17,6 +17,7 @@ describe 'rsync::server', :type => :class do
           })
           is_expected.to contain_concat__fragment('rsyncd_conf_header').with_content(/^use chroot\s*=\s*yes$/)
           is_expected.to contain_concat__fragment('rsyncd_conf_header').with_content(/^address\s*=\s*0.0.0.0$/)
+          is_expected.to contain_concat__fragment('rsyncd_conf_header').with_content(/^pid file\s*=\s*\/var\/run\/rsyncd.pid$/)
         }
       end
 
@@ -45,6 +46,16 @@ describe 'rsync::server', :type => :class do
 
         it {
           is_expected.to contain_file('/etc/rsync-motd')
+        }
+      end
+
+      describe 'when unsetting pid file' do
+        let :params do
+          { :pid_file => 'UNSET' }
+        end
+
+        it {
+          is_expected.not_to contain_concat__fragment('rsyncd_conf_header').with_content(/^pid file\s*=/)
         }
       end
 

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -1,7 +1,9 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
 
-pid file = /var/run/rsyncd.pid
+<% if @pid_file != 'UNSET' -%>
+pid file = <%= @pid_file %>
+<% end -%>
 uid = <%= @uid %>
 gid = <%= @gid %>
 use chroot = <%= @use_chroot %>


### PR DESCRIPTION
Makes the pid_file setting configurable. Setting is skipped if set to
"UNSET", which can be helpful in environments that don't require a PID
file, for example within containers.

This patch does not change the default setting.