### PR TITLE
Bump compatibility versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,14 +8,14 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-rsync",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">=4.2.0 <5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">=4.2.0 <7.0.0"},
     {"name":"puppetlabs/xinetd","version_requirement":">=1.1.0 < 4.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 <5.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 <7.0.0"}
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Tested version compatibilities needed to get the module running with a current version of Puppet modules.