### PR TITLE
Add support to disable pid file in rsync server

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -11,6 +11,7 @@ class rsync::server(
   $address    = '0.0.0.0',
   $motd_file  = 'UNSET',
   $use_chroot = 'yes',
+  $enable_pid = true,
   $uid        = 'nobody',
   $gid        = 'nobody',
   $modules    = {},

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -12,6 +12,7 @@ describe 'rsync::server', :type => :class do
           is_expected.to contain_xinetd__service('rsync').with({ 'bind' => '0.0.0.0' })
           is_expected.not_to contain_service('rsync')
           is_expected.not_to contain_file('/etc/rsync-motd')
+          is_expected.to contain_concat__fragment('rsyncd_conf_header').with_context(/^pid file\s*=\s*\/var\/run\/rsyncd\.pid$/)
           is_expected.to contain_concat__fragment('rsyncd_conf_header').with({
             :order => '00_header',
           })
@@ -65,6 +66,16 @@ describe 'rsync::server', :type => :class do
 
         it {
           is_expected.to contain_concat__fragment('rsyncd_conf_header').with_content(/^address\s*=\s*10.0.0.42$/)
+        }
+      end
+
+      describe 'when disabling pid file' do
+        let :params do
+          { :enable_pid => false }
+        end
+
+        it {
+          is_expected.to_not contain_concat__fragment('rsyncd_conf_header').with_context(/^pid file\s*=.*/)
         }
       end
 

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -1,7 +1,9 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
 
+<% if $enable_pid -%>
 pid file = /var/run/rsyncd.pid
+<% end -%>
 uid = <%= @uid %>
 gid = <%= @gid %>
 use chroot = <%= @use_chroot %>


### PR DESCRIPTION
Add the rsync::server::enable_pid parameter so that we can disable
pid file, which is useful when we run rsync inside containers.