### PR TITLE
Group nobody doesn't exist on Debian

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -12,7 +12,7 @@ class rsync::server(
   $motd_file  = 'UNSET',
   $use_chroot = 'yes',
   $uid        = 'nobody',
-  $gid        = 'nobody',
+  $gid        = undef,
   $modules    = {},
 ) inherits rsync {
 
@@ -20,22 +20,38 @@ class rsync::server(
     'Debian': {
       $conf_file = '/etc/rsyncd.conf'
       $servicename = 'rsync'
+      if $gid {
+        $mygid = $gid
+      } else {
+        $mygid = 'nogroup'
+      }
     }
-    'Suse': {
+    'Suse', 'RedHat': {
       $conf_file = '/etc/rsyncd.conf'
       $servicename = 'rsyncd'
-    }
-    'RedHat': {
-      $conf_file = '/etc/rsyncd.conf'
-      $servicename = 'rsyncd'
+      if $gid {
+        $mygid = $gid
+      } else {
+        $mygid = 'nobody'
+      }
     }
     'FreeBSD': {
       $conf_file = '/usr/local/etc/rsync/rsyncd.conf'
       $servicename = 'rsyncd'
+      if $gid {
+        $mygid = $gid
+      } else {
+        $mygid = 'nobody'
+      }
     }
     default: {
       $conf_file = '/etc/rsync.conf'
       $servicename = 'rsync'
+      if $gid {
+        $mygid = $gid
+      } else {
+        $mygid = 'nobody'
+      }
     }
   }
 

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -3,7 +3,7 @@
 
 pid file = /var/run/rsyncd.pid
 uid = <%= @uid %>
-gid = <%= @gid %>
+gid = <%= @mygid %>
 use chroot = <%= @use_chroot %>
 log format = %t %a %m %f %b
 syslog facility = local3


### PR DESCRIPTION
Debian systems have `nogroup` instead of `nobody` group.