### PR TITLE
Add fake_super option

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -14,6 +14,7 @@ class rsync::server(
   $use_chroot = 'yes',
   $uid        = 'nobody',
   $gid        = 'nobody',
+  $fake_super = undef,
   $modules    = {},
 ) inherits rsync {
 

--- a/manifests/server/module.pp
+++ b/manifests/server/module.pp
@@ -35,6 +35,7 @@
 #   $exclude            - list of files to exclude
 #   $exclude_from       - file containing a list of files to exclude
 #   $dont_compress      - disable compression on matching files
+#   $fake_super         - yes||no, store permission information in extended attributes, to allow running rsyncd as an unprivileged user
 #
 #   sets up an rsync server
 #
@@ -77,7 +78,8 @@ define rsync::server::module (
   $exclude            = undef,
   $exclude_from       = undef,
   $dont_compress      = undef,
-  $ignore_nonreadable = undef)  {
+  $ignore_nonreadable = undef,
+  $fake_super         = undef)  {
 
   concat::fragment { "frag-${name}":
     content => template('rsync/module.erb'),

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -14,3 +14,6 @@ address = <%= @address %>
 <% if @motd_file != 'UNSET' -%>
 motd file = <%= @motd_file %>
 <% end -%>
+<% if @fake_super -%>
+fake super = <%= @fake_super %>
+<% end -%>

--- a/templates/module.erb
+++ b/templates/module.erb
@@ -75,3 +75,6 @@ exclude from       = <%= @exclude_from%>
 <% if @dont_compress -%>
 dont compress      = <%= Array(@dont_compress).join(' ')%>
 <% end -%>
+<% if @fake_super -%>
+fake super = <%= @fake_super %>
+<% end -%>


### PR DESCRIPTION
This adds a parameter to set the "fake super" option in rsyncd.conf. It can be set both globally and per-module.