### PR TITLE
Install rsync-daemon in CentOS >= 8 when not using xinetd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       stage: deploy
 branches:
   only:
-    - master
+    - main
     - /^v\d/
 notifications:
   email: false

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -50,6 +50,15 @@ class rsync::server(
       require     => Package['rsync'],
     }
   } else {
+    if ($facts['os']['family'] == 'RedHat') and
+        (Integer($facts['os']['release']['major']) >= 8) and
+        ($rsync::manage_package) {
+      package { 'rsync-daemon':
+        ensure => $rsync::package_ensure,
+        notify => Service[$servicename],
+      }
+    }
+
     service { $servicename:
       ensure     => running,
       enable     => true,

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.2.0 <7.0.0"
+      "version_requirement": ">=4.2.0 <9.0.0"
     },
     {
       "name": "puppetlabs/xinetd",
@@ -26,7 +26,8 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6.0",
-        "7.0"
+        "7.0",
+        "8.0"
       ]
     },
     {

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -35,6 +35,9 @@ describe 'rsync::server', type: :class do
                         'rsync'
                       end
         it { is_expected.to contain_service(servicename) }
+        if facts[:os][:family] == 'RedHat' && Integer(facts[:os][:release][:major]) >= 8
+          it { is_expected.to contain_package('rsync-daemon') }
+        end
       end
 
       describe 'when setting an motd' do


### PR DESCRIPTION
Since CentOS 8, rsyncd systemd unit is shipped in a different package,
rsync-dameon. When setting use_xinetd to false in rsync::server, this
package should be installed for CentOS >= 8.