### PR TITLE
Fix branch name to run Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       stage: deploy
 branches:
   only:
-    - master
+    - main
     - /^v\d/
 notifications:
   email: false


### PR DESCRIPTION
The default branch has been changed from master to main, so we should
change the branch to run Travis CI as well.