### PR TITLE
Remove github_changelog_generator

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,7 +7,3 @@ appveyor.yml:
 .github/workflows/release.yml:
   unmanaged: false
 
-Gemfile:
-  optional:
-    ':development':
-    - gem: 'github_changelog_generator'

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ group :development do
   gem "rubocop-rspec", '= 2.19.0',               require: false
   gem "puppet-strings", '~> 4.0',                require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "github_changelog_generator",              require: false
 end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]


### PR DESCRIPTION
The workflows use a different, better, maintained tool now.
https://github.com/chelnak/gh-changelog
